### PR TITLE
feat: bootstrap ai flow orchestrator repo

### DIFF
--- a/ai-flow-orchestrator/.github/workflows/dispatch-to-n8n.yml
+++ b/ai-flow-orchestrator/.github/workflows/dispatch-to-n8n.yml
@@ -1,0 +1,26 @@
+name: Disparar webhook n8n
+
+on:
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: "Contenido opcional a enviar en el webhook"
+        required: false
+        default: "{}"
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    env:
+      N8N_WEBHOOK_URL: ${{ secrets.N8N_WEBHOOK_URL }}
+    steps:
+      - name: Verificar webhook configurado
+        if: env.N8N_WEBHOOK_URL == ''
+        run: echo "N8N_WEBHOOK_URL no está definido. Nada que ejecutar."
+      - name: Enviar webhook
+        if: env.N8N_WEBHOOK_URL != ''
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            --data '${{ github.event.inputs.payload || '{}' }}' \
+            "$N8N_WEBHOOK_URL"

--- a/ai-flow-orchestrator/.github/workflows/import-to-n8n.yml
+++ b/ai-flow-orchestrator/.github/workflows/import-to-n8n.yml
@@ -1,0 +1,31 @@
+name: Importar flujos a n8n
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  import:
+    if: github.event.label.name == 'import-to-n8n'
+    runs-on: ubuntu-latest
+    env:
+      N8N_IMPORT_MODE: create-only
+      N8N_URL: ${{ secrets.N8N_URL }}
+      N8N_API_KEY: ${{ secrets.N8N_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configurar Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Validar contratos pendientes
+        run: node scripts/validate_contract.mjs patches/pending
+        working-directory: ai-flow-orchestrator
+      - name: Importar a n8n (create-only)
+        env:
+          N8N_URL: ${{ env.N8N_URL }}
+          N8N_API_KEY: ${{ env.N8N_API_KEY }}
+        run: node scripts/n8n_upsert.mjs patches/pending
+        working-directory: ai-flow-orchestrator

--- a/ai-flow-orchestrator/README.md
+++ b/ai-flow-orchestrator/README.md
@@ -1,0 +1,46 @@
+# AI Flow Orchestrator
+
+Este repositorio mínimo viable coordina la generación, validación e importación de flujos de trabajo para n8n (Community Edition) bajo una política **create-only**. Los cambios se describen como contratos JSON almacenados en `patches/pending/` y posteriormente importados automáticamente a n8n mediante GitHub Actions.
+
+## Componentes principales
+
+- **prompts/**: Contienen los prompts para el rol de editor (genera contratos JSON válidos de n8n) y para el rol de committer (sintetiza mensajes de commit y PR).
+- **flows/n8n/**: Directorio destinado a los exports completos de workflows. Se mantiene vacío hasta que un contrato aplicado cree nuevos flujos.
+- **patches/pending/**: Carpeta con contratos pendientes de importar. Cada contrato describe una o varias piezas (`artifacts`) que deben almacenarse bajo `flows/n8n/`.
+- **scripts/**:
+  - `validate_contract.mjs`: Verifica que los contratos cumplan con el esquema requerido antes de importarlos.
+  - `n8n_upsert.mjs`: Importa los workflows a n8n creando siempre nuevas copias con sufijo `-bot-<timestamp>`.
+- **.github/workflows/**:
+  - `import-to-n8n.yml`: Automatiza la validación e importación cuando un Pull Request recibe la etiqueta `import-to-n8n`.
+  - `dispatch-to-n8n.yml`: Permite disparar manualmente un webhook opcional para integraciones adicionales.
+
+## Flujo de trabajo
+
+1. El editor genera un contrato JSON usando el prompt `PROMPT_EDITOR_DE_FLUJOS_N8N.md` y lo coloca en `patches/pending/`.
+2. Antes de fusionar los cambios, el contrato es validado con `node scripts/validate_contract.mjs patches/pending`.
+3. Al etiquetar un Pull Request con `import-to-n8n`, el workflow `import-to-n8n.yml` ejecuta la validación y luego `node scripts/n8n_upsert.mjs patches/pending`, importando automáticamente los workflows a n8n con modo create-only.
+4. El committer sintetiza mensajes usando el prompt `PROMPT_COMMITTER_N8N.md` para mantener consistencia en commits y Pull Requests.
+
+## Requisitos de entorno
+
+- Node.js 20+
+- Variables de entorno/secrets disponibles en GitHub Actions:
+  - `N8N_URL`: URL base de la instancia n8n (sin credenciales incrustadas).
+  - `N8N_API_KEY`: API Key con permisos para crear workflows.
+  - `N8N_WEBHOOK_URL` (opcional): Webhook externo para orquestación adicional.
+
+## Ejecución manual
+
+```bash
+# Validar contratos pendientes
+node scripts/validate_contract.mjs patches/pending
+
+# Importar contratos (requiere N8N_URL y N8N_API_KEY configurados)
+N8N_URL="https://tu-instancia.n8n.app" \
+N8N_API_KEY="tu_api_key" \
+node scripts/n8n_upsert.mjs patches/pending
+```
+
+## Contratos de ejemplo
+
+Se incluye `patches/pending/ejemplo.json` con un contrato que crea un flujo "Hello Webhook" compuesto por dos nodos: Webhook y Respond to Webhook. Este export sirve como referencia del formato esperado.

--- a/ai-flow-orchestrator/patches/pending/ejemplo.json
+++ b/ai-flow-orchestrator/patches/pending/ejemplo.json
@@ -1,0 +1,65 @@
+{
+  "target": "n8n",
+  "intent": "create",
+  "artifacts": [
+    {
+      "path": "flows/n8n/hello_webhook.json",
+      "mode": "overwrite",
+      "content": {
+        "name": "Hello Webhook",
+        "nodes": [
+          {
+            "parameters": {
+              "httpMethod": "GET",
+              "path": "hello-bot",
+              "options": {}
+            },
+            "id": "Webhook_node_1",
+            "name": "Webhook",
+            "type": "n8n-nodes-base.webhook",
+            "typeVersion": 1,
+            "position": [
+              240,
+              300
+            ],
+            "webhookId": "a1b2c3d4e5f6"
+          },
+          {
+            "parameters": {
+              "responseMode": "onReceived",
+              "responseBody": "Hello from n8n",
+              "options": {}
+            },
+            "id": "Respond_node_1",
+            "name": "Respond to Webhook",
+            "type": "n8n-nodes-base.respondToWebhook",
+            "typeVersion": 1,
+            "position": [
+              520,
+              300
+            ]
+          }
+        ],
+        "connections": {
+          "Webhook": {
+            "main": [
+              [
+                {
+                  "node": "Respond to Webhook",
+                  "type": "main",
+                  "index": 0
+                }
+              ]
+            ]
+          }
+        },
+        "settings": {},
+        "pinData": {},
+        "staticData": {},
+        "meta": {
+          "templateCredsSetupCompleted": true
+        }
+      }
+    }
+  ]
+}

--- a/ai-flow-orchestrator/prompts/PROMPT_COMMITTER_N8N.md
+++ b/ai-flow-orchestrator/prompts/PROMPT_COMMITTER_N8N.md
@@ -1,0 +1,17 @@
+Genera exclusivamente un objeto JSON con el siguiente formato:
+
+{
+  "commit": {
+    "message": "<mensaje>"
+  },
+  "pr": {
+    "title": "<titulo>",
+    "body": "<cuerpo>"
+  }
+}
+
+Reglas obligatorias:
+- No añadas texto fuera del JSON.
+- El `commit.message` debe seguir la convención `feat(n8n): ...`, `fix(n8n): ...` o `refactor(n8n): ...` según el tipo de cambio.
+- `pr.title` debe reutilizar la misma convención que el commit.
+- `pr.body` debe ser un resumen en formato Markdown (puede incluir listas) del cambio y pruebas realizadas.

--- a/ai-flow-orchestrator/prompts/PROMPT_EDITOR_DE_FLUJOS_N8N.md
+++ b/ai-flow-orchestrator/prompts/PROMPT_EDITOR_DE_FLUJOS_N8N.md
@@ -1,0 +1,15 @@
+Eres un asistente especialista en n8n. Tu tarea es producir **únicamente** un contrato JSON válido para la orquestación de flujos siguiendo estas reglas estrictas:
+
+- El resultado debe ser un objeto JSON sin texto adicional antes o después.
+- Usa `"target": "n8n"`.
+- Define `"intent"` con el valor `"create"` o `"update"` según corresponda.
+- Incluye un arreglo `"artifacts"` donde cada elemento describe un archivo bajo `flows/n8n/`.
+- Para cada artifact:
+  - `"path"` **debe** comenzar con `"flows/n8n/"` y terminar con `.json`.
+  - `"mode"` **debe** ser `"overwrite"`.
+  - `"content"` **debe** contener un export COMPLETO de n8n en formato JSON, con al menos los campos `"name"`, `"nodes"` y `"connections"`.
+  - Asegúrate de que `"nodes"` y `"connections"` representen un flujo funcional y coherente.
+- No incluyas credenciales ni secretos. Usa valores de ejemplo seguros.
+- No agregues comentarios, markdown, ni explicaciones. Solo el JSON final.
+
+Si necesitas crear varios workflows en un mismo contrato, agrega múltiples objetos dentro de `"artifacts"`. Cada export debe ser autónomo y válido para importarse en n8n.

--- a/ai-flow-orchestrator/scripts/n8n_upsert.mjs
+++ b/ai-flow-orchestrator/scripts/n8n_upsert.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const N8N_URL = process.env.N8N_URL;
+const N8N_API_KEY = process.env.N8N_API_KEY;
+
+if (!N8N_URL) {
+  console.error('La variable de entorno N8N_URL es obligatoria.');
+  process.exit(1);
+}
+
+if (!N8N_API_KEY) {
+  console.error('La variable de entorno N8N_API_KEY es obligatoria.');
+  process.exit(1);
+}
+
+function normalizeBaseUrl(url) {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function ensureN8nExport(data, context) {
+  if (data == null || typeof data !== 'object') {
+    throw new Error(`${context}: el contenido del export debe ser un objeto JSON.`);
+  }
+  if (!('nodes' in data) || !Array.isArray(data.nodes)) {
+    throw new Error(`${context}: el export debe incluir un arreglo "nodes" válido.`);
+  }
+  if (!('connections' in data) || typeof data.connections !== 'object') {
+    throw new Error(`${context}: el export debe incluir un objeto "connections".`);
+  }
+}
+
+async function readJsonFile(filePath) {
+  const content = await fs.readFile(filePath, 'utf8');
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`No se pudo parsear JSON en ${filePath}: ${error.message}`);
+  }
+}
+
+async function createWorkflow(exportData) {
+  const timestampSuffix = `-bot-${Date.now()}`;
+  const workflowName = exportData.name ? `${exportData.name}${timestampSuffix}` : `workflow${timestampSuffix}`;
+  const payload = { ...exportData, name: workflowName };
+
+  const response = await fetch(`${normalizeBaseUrl(N8N_URL)}/rest/workflows`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-N8N-API-KEY': N8N_API_KEY,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Error al crear workflow "${workflowName}": ${response.status} ${response.statusText} - ${body}`);
+  }
+
+  const result = await response.json();
+  console.log(`Workflow creado: ${result.name || workflowName} (ID: ${result.id ?? 'desconocido'})`);
+}
+
+async function processContractFile(filePath) {
+  const contract = await readJsonFile(filePath);
+  if (!Array.isArray(contract.artifacts)) {
+    throw new Error(`${filePath}: el contrato debe contener un arreglo "artifacts".`);
+  }
+
+  for (const [index, artifact] of contract.artifacts.entries()) {
+    const artifactId = `${path.basename(filePath)} -> artifacts[${index}]`;
+    if (!artifact || typeof artifact !== 'object') {
+      throw new Error(`${artifactId}: artifact inválido.`);
+    }
+
+    let exportContent = artifact.content;
+    if (typeof exportContent === 'string') {
+      try {
+        exportContent = JSON.parse(exportContent);
+      } catch (error) {
+        throw new Error(`${artifactId}: contenido no es JSON válido: ${error.message}`);
+      }
+    }
+
+    ensureN8nExport(exportContent, artifactId);
+    await createWorkflow(exportContent);
+  }
+}
+
+async function main() {
+  const targetDir = process.argv[2];
+  if (!targetDir) {
+    console.error('Uso: node scripts/n8n_upsert.mjs <directorio>');
+    process.exit(1);
+  }
+
+  const resolvedDir = path.resolve(process.cwd(), targetDir);
+  let files;
+  try {
+    files = await fs.readdir(resolvedDir);
+  } catch (error) {
+    console.error(`No se pudo leer el directorio ${resolvedDir}: ${error.message}`);
+    process.exit(1);
+  }
+
+  const jsonFiles = files.filter((name) => name.endsWith('.json'));
+  if (jsonFiles.length === 0) {
+    console.error(`No se encontraron contratos JSON en ${resolvedDir}.`);
+    process.exit(1);
+  }
+
+  try {
+    for (const file of jsonFiles) {
+      const fullPath = path.join(resolvedDir, file);
+      console.log(`Procesando contrato: ${path.basename(file)}`);
+      await processContractFile(fullPath);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/ai-flow-orchestrator/scripts/validate_contract.mjs
+++ b/ai-flow-orchestrator/scripts/validate_contract.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function readJsonFile(filePath) {
+  const content = await fs.readFile(filePath, 'utf8');
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`No se pudo parsear JSON en ${filePath}: ${error.message}`);
+  }
+}
+
+function ensureN8nExport(data, context) {
+  if (data == null || typeof data !== 'object') {
+    throw new Error(`${context}: el contenido del export debe ser un objeto JSON.`);
+  }
+  if (!('nodes' in data) || !Array.isArray(data.nodes)) {
+    throw new Error(`${context}: el export debe incluir un arreglo "nodes" válido.`);
+  }
+  if (!('connections' in data) || typeof data.connections !== 'object') {
+    throw new Error(`${context}: el export debe incluir un objeto "connections".`);
+  }
+}
+
+async function validateContractFile(filePath) {
+  const contract = await readJsonFile(filePath);
+  if (contract.target !== 'n8n') {
+    throw new Error(`${filePath}: "target" debe ser "n8n".`);
+  }
+  if (!Array.isArray(contract.artifacts) || contract.artifacts.length === 0) {
+    throw new Error(`${filePath}: "artifacts" debe ser un arreglo no vacío.`);
+  }
+
+  for (const [index, artifact] of contract.artifacts.entries()) {
+    const artifactId = `${filePath} -> artifacts[${index}]`;
+    if (!artifact || typeof artifact !== 'object') {
+      throw new Error(`${artifactId}: artifact inválido.`);
+    }
+    if (typeof artifact.path !== 'string' || !artifact.path.startsWith('flows/n8n/')) {
+      throw new Error(`${artifactId}: "path" debe iniciar con "flows/n8n/".`);
+    }
+    if (artifact.mode !== 'overwrite') {
+      throw new Error(`${artifactId}: "mode" debe ser "overwrite".`);
+    }
+    if (!('content' in artifact)) {
+      throw new Error(`${artifactId}: falta "content".`);
+    }
+
+    let exportContent = artifact.content;
+    if (typeof exportContent === 'string') {
+      try {
+        exportContent = JSON.parse(exportContent);
+      } catch (error) {
+        throw new Error(`${artifactId}: contenido no es JSON válido: ${error.message}`);
+      }
+    }
+    ensureN8nExport(exportContent, artifactId);
+  }
+
+  console.log(`Contrato válido: ${path.basename(filePath)}`);
+}
+
+async function main() {
+  const targetDir = process.argv[2];
+  if (!targetDir) {
+    console.error('Uso: node scripts/validate_contract.mjs <directorio>');
+    process.exit(1);
+  }
+
+  const resolvedDir = path.resolve(process.cwd(), targetDir);
+  let files;
+  try {
+    files = await fs.readdir(resolvedDir);
+  } catch (error) {
+    console.error(`No se pudo leer el directorio ${resolvedDir}: ${error.message}`);
+    process.exit(1);
+  }
+
+  const jsonFiles = files.filter((name) => name.endsWith('.json'));
+  if (jsonFiles.length === 0) {
+    console.error(`No se encontraron contratos JSON en ${resolvedDir}.`);
+    process.exit(1);
+  }
+
+  try {
+    for (const file of jsonFiles) {
+      const fullPath = path.join(resolvedDir, file);
+      await validateContractFile(fullPath);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- scaffold repository structure for n8n flow orchestration with create-only policy
- add prompts, validation and import scripts plus example contract
- configure GitHub Actions workflows for validation, import and optional webhook dispatch

## Testing
- node ai-flow-orchestrator/scripts/validate_contract.mjs ai-flow-orchestrator/patches/pending

------
https://chatgpt.com/codex/tasks/task_e_68cdbfddb9388324a09f3a7b20299d69